### PR TITLE
Add fake project repository and use case tests

### DIFF
--- a/app/src/test/java/com/comp/lyricsapp/domain/usecases/CreateProjectUseCaseTest.kt
+++ b/app/src/test/java/com/comp/lyricsapp/domain/usecases/CreateProjectUseCaseTest.kt
@@ -1,0 +1,23 @@
+package com.comp.lyricsapp.domain.usecases
+
+import com.comp.lyricsapp.data.repo.ProjectRepositoryImpl
+import com.comp.lyricsapp.domain.entities.Project
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CreateProjectUseCaseTest {
+    @Test
+    fun `CreateProjectUseCase calls create on the repository`() {
+        val local = FakeProjectRepository()
+        val remote = FakeProjectRepository()
+        val repository = ProjectRepositoryImpl(local, remote)
+        val useCase = CreateProjectUseCase(repository)
+
+        val project = Project(1L, "test", "now")
+
+        useCase(project)
+
+        assertEquals(1, local.createdProjects.size)
+        assertEquals(project, local.createdProjects.first())
+    }
+}

--- a/app/src/test/java/com/comp/lyricsapp/domain/usecases/DeleteProjectUseCaseTest.kt
+++ b/app/src/test/java/com/comp/lyricsapp/domain/usecases/DeleteProjectUseCaseTest.kt
@@ -1,0 +1,23 @@
+package com.comp.lyricsapp.domain.usecases
+
+import com.comp.lyricsapp.data.repo.ProjectRepositoryImpl
+import com.comp.lyricsapp.domain.entities.Project
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DeleteProjectUseCaseTest {
+    @Test
+    fun `DeleteProjectUseCase calls delete on the repository`() {
+        val local = FakeProjectRepository()
+        val remote = FakeProjectRepository()
+        val repository = ProjectRepositoryImpl(local, remote)
+        val useCase = DeleteProjectUseCase(repository)
+
+        val project = Project(3L, "delete", "time")
+
+        useCase(project)
+
+        assertEquals(1, local.deletedProjects.size)
+        assertEquals(project, local.deletedProjects.first())
+    }
+}

--- a/app/src/test/java/com/comp/lyricsapp/domain/usecases/FakeProjectRepository.kt
+++ b/app/src/test/java/com/comp/lyricsapp/domain/usecases/FakeProjectRepository.kt
@@ -1,0 +1,51 @@
+package com.comp.lyricsapp.domain.usecases
+
+import com.comp.lyricsapp.domain.entities.Project
+import com.comp.lyricsapp.domain.entities.ProjectWithBars
+import com.comp.lyricsapp.domain.repositories.ProjectRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
+
+/**
+ * Simple fake implementation of [ProjectRepository] used for unit testing.
+ * It records calls to each method so that tests can assert interactions.
+ */
+class FakeProjectRepository(
+    var allProjectsFlow: Flow<List<Project>> = flowOf(emptyList()),
+    var projectWithBarsFlow: Flow<ProjectWithBars> = emptyFlow()
+) : ProjectRepository {
+
+    val createdProjects = mutableListOf<Project>()
+    val updatedProjects = mutableListOf<Project>()
+    val deletedProjects = mutableListOf<Project>()
+    var deleteAllCalls = 0
+    var getAllCalls = 0
+    val getProjectWithBarsCalls = mutableListOf<Long>()
+
+    override fun getAll(): Flow<List<Project>> {
+        getAllCalls++
+        return allProjectsFlow
+    }
+
+    override fun getProjectWithBars(id: Long): Flow<ProjectWithBars> {
+        getProjectWithBarsCalls.add(id)
+        return projectWithBarsFlow
+    }
+
+    override suspend fun update(updatedProject: Project) {
+        updatedProjects.add(updatedProject)
+    }
+
+    override suspend fun deleteAll() {
+        deleteAllCalls++
+    }
+
+    override suspend fun delete(project: Project) {
+        deletedProjects.add(project)
+    }
+
+    override suspend fun create(project: Project) {
+        createdProjects.add(project)
+    }
+}

--- a/app/src/test/java/com/comp/lyricsapp/domain/usecases/GetAllProjectsUseCaseTest.kt
+++ b/app/src/test/java/com/comp/lyricsapp/domain/usecases/GetAllProjectsUseCaseTest.kt
@@ -1,0 +1,24 @@
+package com.comp.lyricsapp.domain.usecases
+
+import com.comp.lyricsapp.data.repo.ProjectRepositoryImpl
+import com.comp.lyricsapp.domain.entities.Project
+import kotlinx.coroutines.flow.flowOf
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+class GetAllProjectsUseCaseTest {
+    @Test
+    fun `GetAllProjectsUseCase returns repository flow`() {
+        val expectedFlow = flowOf(listOf(Project(4L, "title", "ts")))
+        val local = FakeProjectRepository(allProjectsFlow = expectedFlow)
+        val remote = FakeProjectRepository()
+        val repository = ProjectRepositoryImpl(local, remote)
+        val useCase = GetAllProjectsUseCase(repository)
+
+        val result = useCase(Unit, async = false)
+
+        assertSame(expectedFlow, result)
+        assertEquals(1, local.getAllCalls)
+    }
+}

--- a/app/src/test/java/com/comp/lyricsapp/domain/usecases/UpdateProjectUseCaseTest.kt
+++ b/app/src/test/java/com/comp/lyricsapp/domain/usecases/UpdateProjectUseCaseTest.kt
@@ -1,0 +1,23 @@
+package com.comp.lyricsapp.domain.usecases
+
+import com.comp.lyricsapp.data.repo.ProjectRepositoryImpl
+import com.comp.lyricsapp.domain.entities.Project
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class UpdateProjectUseCaseTest {
+    @Test
+    fun `UpdateProjectUseCase calls update on the repository`() {
+        val local = FakeProjectRepository()
+        val remote = FakeProjectRepository()
+        val repository = ProjectRepositoryImpl(local, remote)
+        val useCase = UpdateProjectUseCase(repository)
+
+        val project = Project(2L, "update", "time")
+
+        useCase(project)
+
+        assertEquals(1, local.updatedProjects.size)
+        assertEquals(project, local.updatedProjects.first())
+    }
+}


### PR DESCRIPTION
## Summary
- create `FakeProjectRepository` for verifying repository interactions
- unit test create, update, delete, and get-all project use cases

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684145f786e483298084cb7779ef208c