### PR TITLE
Add repository fakes and use case delegation tests

### DIFF
--- a/app/src/main/java/com/comp/lyricsapp/data/repo/BarRepositoryImpl.kt
+++ b/app/src/main/java/com/comp/lyricsapp/data/repo/BarRepositoryImpl.kt
@@ -8,7 +8,7 @@ import com.comp.lyricsapp.domain.repositories.BarRepository
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
-class BarRepositoryImpl @Inject constructor(
+open class BarRepositoryImpl @Inject constructor(
     private val localBarRepository: LocalBarRepository,
     private val remoteBarRepository: RemoteBarRepository
 ): BarRepository {

--- a/app/src/main/java/com/comp/lyricsapp/data/repo/LineRepositoryImpl.kt
+++ b/app/src/main/java/com/comp/lyricsapp/data/repo/LineRepositoryImpl.kt
@@ -7,7 +7,7 @@ import com.comp.lyricsapp.domain.repositories.LineRepository
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
-class LineRepositoryImpl @Inject constructor(
+open class LineRepositoryImpl @Inject constructor(
     private val localLineRepository: LocalLineRepository,
     private val remoteLineRepository: RemoteLineRepository
 ): LineRepository {

--- a/app/src/test/java/com/comp/lyricsapp/domain/usecases/BarUseCasesTest.kt
+++ b/app/src/test/java/com/comp/lyricsapp/domain/usecases/BarUseCasesTest.kt
@@ -1,0 +1,53 @@
+package com.comp.lyricsapp.domain.usecases
+
+import com.comp.lyricsapp.domain.entities.Bar
+import com.comp.lyricsapp.domain.entities.Line
+import kotlinx.coroutines.flow.first
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class BarUseCasesTest {
+    private val repository = BarRepositoryImplFake()
+    private val createBar = CreateBar(repository)
+    private val updateBar = UpdateBar(repository)
+    private val deleteProjectBar = DeleteProjectBar(repository)
+    private val deleteProjectBars = DeleteProjectBars(repository)
+    private val getBarLinesUseCase = GetBarLinesUseCase(repository)
+
+    @Test
+    fun `CreateBar delegates to repository`() {
+        val bar = Bar(1L, 2L)
+        createBar(bar)
+        assertEquals(bar, repository.createdBar)
+    }
+
+    @Test
+    fun `UpdateBar delegates to repository`() {
+        val bar = Bar(2L, 1L)
+        updateBar(bar)
+        assertEquals(bar, repository.updatedBar)
+    }
+
+    @Test
+    fun `DeleteProjectBar delegates to repository`() {
+        val projectId = 1L
+        val barId = 5L
+        deleteProjectBar(ProjectBarIds(projectId, barId))
+        assertEquals(projectId to listOf(barId), repository.deleteProjectBarsArgs)
+    }
+
+    @Test
+    fun `DeleteProjectBars delegates to repository`() {
+        val projectId = 3L
+        deleteProjectBars(projectId)
+        assertEquals(projectId, repository.deleteAllProjectBarsArg)
+    }
+
+    @Test
+    fun `GetBarLinesUseCase delegates to repository`() {
+        val id = 7L
+        val lines = getBarLinesUseCase(id, async = false).first()
+        assertEquals(id, repository.getBarLinesArg)
+        assertEquals(emptyList<Line>(), lines)
+    }
+}

--- a/app/src/test/java/com/comp/lyricsapp/domain/usecases/LineUseCasesTest.kt
+++ b/app/src/test/java/com/comp/lyricsapp/domain/usecases/LineUseCasesTest.kt
@@ -1,0 +1,35 @@
+package com.comp.lyricsapp.domain.usecases
+
+import com.comp.lyricsapp.domain.entities.BarWithLines
+import com.comp.lyricsapp.domain.entities.Bar
+import com.comp.lyricsapp.domain.entities.Line
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LineUseCasesTest {
+    private val repository = LineRepositoryImplFake()
+    private val createLine = CreateLineUseCase(repository)
+    private val updateLine = UpdateLineUseCase(repository)
+    private val deleteBarLine = DeleteBarLineUseCase(repository)
+
+    @Test
+    fun `CreateLineUseCase delegates to repository`() {
+        val line = Line(1L, 1L, "", "")
+        createLine(line)
+        assertEquals(line, repository.createdLine)
+    }
+
+    @Test
+    fun `UpdateLineUseCase delegates to repository`() {
+        val line = Line(2L, 1L, "", "")
+        updateLine(line)
+        assertEquals(line, repository.updatedLine)
+    }
+
+    @Test
+    fun `DeleteBarLineUseCase delegates to repository`() {
+        val barWithLines = BarWithLines(Bar(1L,1L), listOf(Line(3L,1L,"","")))
+        deleteBarLine(barWithLines)
+        assertEquals(barWithLines.barLines, repository.deletedLines)
+    }
+}

--- a/app/src/test/java/com/comp/lyricsapp/domain/usecases/RepositoryFakes.kt
+++ b/app/src/test/java/com/comp/lyricsapp/domain/usecases/RepositoryFakes.kt
@@ -1,0 +1,94 @@
+package com.comp.lyricsapp.domain.usecases
+
+import com.comp.lyricsapp.data.repo.BarRepositoryImpl
+import com.comp.lyricsapp.data.repo.LineRepositoryImpl
+import com.comp.lyricsapp.data.local.repo.LocalBarRepository
+import com.comp.lyricsapp.data.local.repo.LocalLineRepository
+import com.comp.lyricsapp.data.remote.repo.RemoteBarRepository
+import com.comp.lyricsapp.data.remote.repo.RemoteLineRepository
+import com.comp.lyricsapp.data.local.dao.BarDao
+import com.comp.lyricsapp.data.local.dao.LineDao
+import com.comp.lyricsapp.data.remote.api.BarApi
+import com.comp.lyricsapp.data.remote.api.LineApi
+import com.comp.lyricsapp.domain.entities.Bar
+import com.comp.lyricsapp.domain.entities.BarWithLines
+import com.comp.lyricsapp.domain.entities.Line
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+
+// Stub implementations used to satisfy repository constructors
+private class StubBarDao: BarDao {
+    override suspend fun insertBar(barDto: com.comp.lyricsapp.data.model.BarDto): Long = 0L
+    override suspend fun insertLines(lines: List<com.comp.lyricsapp.data.model.LineDto>) {}
+    override fun getBarWithLines(barId: Long): Flow<com.comp.lyricsapp.data.model.relations.BarWithLinesRelationEntity> = flowOf(com.comp.lyricsapp.data.model.relations.BarWithLinesRelationEntity(com.comp.lyricsapp.data.model.BarDto(0L,0L), emptyList()))
+    override suspend fun updateBar(updatedBar: com.comp.lyricsapp.data.model.BarDto) {}
+    override suspend fun deleteProjectBars(projectId: Long, barIds: List<Long>) {}
+    override suspend fun deleteAllProjectBars(projectId: Long) {}
+}
+
+private class StubLineDao: LineDao {
+    override suspend fun insertLine(line: com.comp.lyricsapp.data.model.LineDto) {}
+    override suspend fun updateLine(updatedLine: com.comp.lyricsapp.data.model.LineDto) {}
+    override suspend fun deleteBarLines(lines: List<com.comp.lyricsapp.data.model.LineDto>) {}
+}
+
+private class StubBarApi: BarApi
+private class StubLineApi: LineApi
+
+class BarRepositoryImplFake : BarRepositoryImpl(
+    LocalBarRepository(StubBarDao()),
+    RemoteBarRepository(StubBarApi())
+) {
+    var updatedBar: Bar? = null
+    var createdBar: Bar? = null
+    var deleteProjectBarsArgs: Pair<Long,List<Long>>? = null
+    var deleteAllProjectBarsArg: Long? = null
+    var getBarLinesArg: Long? = null
+
+    override suspend fun updateBar(updatedBar: Bar) {
+        this.updatedBar = updatedBar
+    }
+
+    override suspend fun deleteProjectBars(projectId: Long, projectBarIds: List<Long>) {
+        deleteProjectBarsArgs = projectId to projectBarIds
+    }
+
+    override suspend fun deleteAllProjectBars(projectId: Long) {
+        deleteAllProjectBarsArg = projectId
+    }
+
+    override suspend fun createBar(bar: Bar) {
+        createdBar = bar
+    }
+
+    override fun getBarWithLines(barId: Long): Flow<BarWithLines> {
+        getBarLinesArg = barId
+        return flowOf(BarWithLines(Bar(barId, -1), emptyList()))
+    }
+}
+
+class LineRepositoryImplFake : LineRepositoryImpl(
+    LocalLineRepository(StubLineDao()),
+    RemoteLineRepository(StubLineApi())
+) {
+    var insertedLine: Line? = null
+    var updatedLine: Line? = null
+    var deletedLines: List<Line>? = null
+    var createdLine: Line? = null
+
+    override suspend fun insertLine(newLine: Line) {
+        insertedLine = newLine
+    }
+
+    override suspend fun updateLine(updatedLine: Line) {
+        this.updatedLine = updatedLine
+    }
+
+    override suspend fun deleteBarLines(barLines: List<Line>) {
+        deletedLines = barLines
+    }
+
+    override suspend fun createLine(newLine: Line) {
+        createdLine = newLine
+    }
+}


### PR DESCRIPTION
## Summary
- make repository implementations open for subclassing
- add fake repository implementations for testing
- test that line use cases delegate to the repository
- test that bar use cases delegate to the repository

## Testing
- `./gradlew test --quiet` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684145fb1a7883298885fe4ac2615830